### PR TITLE
Revert "Add Canonical to metadata table in import script"

### DIFF
--- a/tools/importer/rules/metaData.js
+++ b/tools/importer/rules/metaData.js
@@ -64,13 +64,6 @@ export default function createMetadataBlock(document, cardMetadataTable) {
     el.src = img.content;
     meta.Image = el;
   }
-    
-  const canonical = document.querySelector('[rel="canonical"]');
-  if (canonical && canonical.href) {
-     const el = document.createElement('a');
-     el.href = canonical.href;
-     meta.Canonical = el;
-  }
 
   const block = WebImporter.Blocks.getMetadataBlock(document, meta);
   main.append(document.createElement('hr'));


### PR DESCRIPTION
Reverts adobecom/franklin-acom-import#38

With latest discussion with SEO and GWP team Canonical url is not needed with import script and will be maintained by metadata sheet